### PR TITLE
fix installation issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,53 @@ jobs:
           cd dist
           sha256sum * > checksums.txt
 
+      - name: Generate Homebrew formula
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION_NUM="${VERSION#v}"
+          SHA_DARWIN_ARM64=$(grep 'rememory-darwin-arm64$' dist/checksums.txt | awk '{print $1}')
+          SHA_DARWIN_AMD64=$(grep 'rememory-darwin-amd64$' dist/checksums.txt | awk '{print $1}')
+          SHA_LINUX_ARM64=$(grep 'rememory-linux-arm64$' dist/checksums.txt | awk '{print $1}')
+          SHA_LINUX_AMD64=$(grep 'rememory-linux-amd64$' dist/checksums.txt | awk '{print $1}')
+          cat > dist/rememory.rb << FORMULA
+          class Rememory < Formula
+            desc "Encrypt secrets and split them among people you trust"
+            homepage "https://github.com/eljojo/rememory"
+            version "${VERSION_NUM}"
+            license "Apache-2.0"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/eljojo/rememory/releases/download/${VERSION}/rememory-darwin-arm64"
+                sha256 "${SHA_DARWIN_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/eljojo/rememory/releases/download/${VERSION}/rememory-darwin-amd64"
+                sha256 "${SHA_DARWIN_AMD64}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/eljojo/rememory/releases/download/${VERSION}/rememory-linux-arm64"
+                sha256 "${SHA_LINUX_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/eljojo/rememory/releases/download/${VERSION}/rememory-linux-amd64"
+                sha256 "${SHA_LINUX_AMD64}"
+              end
+            end
+
+            def install
+              bin.install Dir.glob("rememory-*").first => "rememory"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/rememory --version")
+            end
+          end
+          FORMULA
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,7 +121,22 @@ jobs:
             dist/checksums.txt \
             dist/maker.html \
             dist/recover.html \
+            dist/rememory.rb \
             --generate-notes \
             --draft
           # Publish the release (now it becomes immutable)
           gh release edit ${{ github.ref_name }} --draft=false
+
+      - name: Update Homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone https://x-access-token:${TAP_TOKEN}@github.com/eljojo/homebrew-rememory.git /tmp/tap
+          mkdir -p /tmp/tap/Formula
+          cp dist/rememory.rb /tmp/tap/Formula/rememory.rb
+          cd /tmp/tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/rememory.rb
+          git commit -m "Update rememory to ${{ github.ref_name }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -58,13 +58,19 @@ Everything runs locally in your browser. Your files never leave your device.
 For automation, scripting, or if you prefer the command line.
 
 ```bash
-# Install
-go install github.com/eljojo/rememory/cmd/rememory@latest
+# macOS (Homebrew)
+brew install eljojo/rememory/rememory
 
-# Or download from GitHub Releases
+# Linux (x86_64)
+curl -Lo rememory https://github.com/eljojo/rememory/releases/latest/download/rememory-linux-amd64
+chmod +x rememory
+sudo mv rememory /usr/local/bin/
+
+# Nix
+nix run github:eljojo/rememory
 ```
 
-See the **[CLI User Guide](docs/guide.md)** for complete documentation.
+See the **[CLI User Guide](docs/guide.md)** for more options and complete documentation.
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -35,24 +35,35 @@ The key innovation is that recovery works **entirely offline in a browser**—no
 
 ## Installation
 
-### From GitHub Releases
-
-Download the latest binary for your platform from [Releases](https://github.com/eljojo/rememory/releases).
-
-### With Go
+### macOS (Homebrew)
 
 ```bash
-go install github.com/eljojo/rememory/cmd/rememory@latest
+brew install eljojo/rememory/rememory
 ```
 
-Optionally, generate man pages:
+### Linux
+
+Download the binary, make it executable, and move it to your path.
+
+**x86_64:**
 
 ```bash
-mkdir -p ~/.local/share/man/man1
-rememory doc ~/.local/share/man/man1
+curl -Lo rememory https://github.com/eljojo/rememory/releases/latest/download/rememory-linux-amd64
+chmod +x rememory
+sudo mv rememory /usr/local/bin/
 ```
 
-### With Nix
+**ARM64:**
+
+```bash
+curl -Lo rememory https://github.com/eljojo/rememory/releases/latest/download/rememory-linux-arm64
+chmod +x rememory
+sudo mv rememory /usr/local/bin/
+```
+
+Binaries for all platforms are available on the [Releases](https://github.com/eljojo/rememory/releases) page.
+
+### Nix
 
 Run directly without installing:
 
@@ -61,7 +72,7 @@ nix run github:eljojo/rememory
 ```
 
 <details>
-<summary>Install</summary>
+<summary>Install permanently</summary>
 
 Add to your flake inputs:
 
@@ -93,6 +104,13 @@ Or in home-manager:
 ```
 
 </details>
+
+### Man pages (optional)
+
+```bash
+mkdir -p ~/.local/share/man/man1
+rememory doc ~/.local/share/man/man1
+```
 
 
 ## Creating Your First Project

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           version = "0.1.0";
           src = ./.;
 
-          vendorHash = "sha256-4voapYXaf792sNI/P2Uj7ujs4x2r0vkb1bzLXr5Y14I=";
+          vendorHash = "sha256-5IB15Mf4Stm5+HuAODMIRQqovZQse0160750XbHkmHU=";
           proxyVendor = true; # Download deps during build instead of vendoring
 
           nativeBuildInputs = [ pkgs.esbuild pkgs.gnumake ];


### PR DESCRIPTION
setup homebrew tap, update linux install instructions, and fix nix flake


This pull request introduces Homebrew packaging and tap automation for the project, making installation on macOS much easier. The release workflow is updated to generate a Homebrew formula and automatically update the Homebrew tap repository with each release. Documentation is improved to reflect these new installation methods, and the Nix flake is updated for dependency consistency.

**Release automation and packaging:**

* Added a step in `.github/workflows/release.yml` to automatically generate a Homebrew formula (`rememory.rb`) for each release, supporting both macOS and Linux on ARM and Intel architectures.
* Enhanced the release workflow to upload the generated Homebrew formula as a release asset and automatically update the `eljojo/homebrew-rememory` tap repository with the new formula on each release.

**Documentation improvements:**

* Updated installation instructions in `README.md` and `docs/guide.md` to prominently feature the new Homebrew installation method for macOS, and clarified Linux and Nix installation steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R73) [[2]](diffhunk://#diff-07fdd026b11c494c3b62c97f764f6939803c453389ebefd6b05e6f187d44859aL38-R66)
* Added a section to the CLI guide on generating and installing man pages for the CLI tool.
* Improved details for Nix installation and clarified documentation language.

**Build system:**

* Updated the `vendorHash` in `flake.nix` to ensure reproducible builds with the latest dependencies.