### PR TITLE
docs: update guide prompts and demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the **[CLI User Guide](docs/guide.md)** for complete documentation.
 
 Before protecting real secrets, try the recovery process:
 
-1. **[Download demo bundles](https://github.com/eljojo/rememory/releases/download/v0.0.3/demo-bundles.zip)** (contains 3 sample bundles)
+1. **[Download demo bundles](https://github.com/eljojo/rememory/releases/latest/download/demo-bundles.zip)** (contains 3 sample bundles)
 2. Open `bundle-alice/recover.html` in your browser
 3. Alice's share is pre-loaded — add Bob's or Carol's
 4. When enough shares are added, the files unlock

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -130,18 +130,15 @@ How many shares needed to recover? [3]: 3
 
 Friend 1:
   Name: Alice
-  Email: alice@example.com
-  Phone (optional): 555-1234
+  Contact info (optional): alice@example.com
 
 Friend 2:
   Name: Bob
-  Email: bob@example.com
-  Phone (optional):
+  Contact info (optional):
 
 Friend 3:
   Name: Carol
-  Email: carol@example.com
-  Phone (optional): 555-3456
+  Contact info (optional): carol@example.com
 
 ...
 ```

--- a/e2e/creation.spec.ts
+++ b/e2e/creation.spec.ts
@@ -16,7 +16,6 @@ test.describe('Browser Bundle Creation Tool', () => {
     // Skip if rememory binary not available
     const bin = getRememoryBin();
     if (!fs.existsSync(bin)) {
-      console.log(`Skipping tests: rememory binary not found at ${bin}`);
       test.skip();
       return;
     }

--- a/e2e/recovery.spec.ts
+++ b/e2e/recovery.spec.ts
@@ -24,7 +24,6 @@ test.describe('Browser Recovery Tool', () => {
     // Skip if rememory binary not available
     const bin = getRememoryBin();
     if (!fs.existsSync(bin)) {
-      console.log(`Skipping tests: rememory binary not found at ${bin}`);
       test.skip();
       return;
     }
@@ -270,7 +269,6 @@ test.describe('Anonymous Bundle Recovery', () => {
     // Skip if rememory binary not available
     const bin = getRememoryBin();
     if (!fs.existsSync(bin)) {
-      console.log(`Skipping tests: rememory binary not found at ${bin}`);
       test.skip();
       return;
     }
@@ -348,7 +346,6 @@ test.describe('Generic recover.html (no personalization)', () => {
   test.beforeAll(async () => {
     const bin = getRememoryBin();
     if (!fs.existsSync(bin)) {
-      console.log(`Skipping tests: rememory binary not found at ${bin}`);
       test.skip();
       return;
     }


### PR DESCRIPTION
## Summary

- The CLI guide still showed separate Email and Phone fields, but that changed with #19 — updated to match the current "Contact info (optional)" prompt
- Demo bundle link in the README pointed at v0.0.3, switched it to `/latest/` so it stays current across releases
- Cleaned up a few leftover `console.log` calls in the E2E test setup

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] Verified `/releases/latest/download/demo-bundles.zip` resolves correctly (302 redirect)
- [x] Confirmed guide prompt text matches `init.go:243`