### PR TITLE
fix language detection for regional browser locales

### DIFF
--- a/internal/html/assets/maker.html
+++ b/internal/html/assets/maker.html
@@ -495,7 +495,9 @@
     // Set initial language immediately
     (function() {
       const saved = localStorage.getItem('rememory-lang');
-      const detected = navigator.languages.find((language) => {{LANG_DETECT}}.includes(language));
+      const langs = {{LANG_DETECT}};
+      const detected = navigator.languages.find((l) => langs.includes(l))
+        || navigator.languages.map((l) => l.split('-')[0]).find((l) => langs.includes(l));
       currentLang = saved || detected || 'en';
     })();
 

--- a/internal/html/assets/recover.html
+++ b/internal/html/assets/recover.html
@@ -178,7 +178,9 @@
     // Set initial language immediately (before app.js runs)
     (function() {
       const saved = localStorage.getItem('rememory-lang');
-      const detected = navigator.languages.find((language) => {{LANG_DETECT}}.includes(language));
+      const langs = {{LANG_DETECT}};
+      const detected = navigator.languages.find((l) => langs.includes(l))
+        || navigator.languages.map((l) => l.split('-')[0]).find((l) => langs.includes(l));
       currentLang = saved || detected || 'en';
     })();
 


### PR DESCRIPTION
Browsers report regional variants (`pt-BR`, `fr-CA`, `es-MX`, `de-AT`) not bare language codes. The current detection uses exact matching against the supported list, so someone with `pt-BR` configured gets English instead of Portuguese.

This adds a fallback: if no exact match is found, strip the region subtag and try again. Exact matches still take priority, so `zh-TW` continues to work as before.

Affects `recover.html` and `maker.html`

## Test plan

- [ ] Set browser language to `pt-BR`, open recover.html - should auto-detect Portuguese
- [ ] Set browser language to `zh-TW` - should still match exactly (no regression)
- [ ] Set browser language to `en-US` - should fall through to English default
- [ ] Saved preference in localStorage should still override detection