### PR TITLE
Linkify email addresses in recover.html contact list

### DIFF
--- a/e2e/recovery.spec.ts
+++ b/e2e/recovery.spec.ts
@@ -76,6 +76,18 @@ test.describe('Browser Recovery Tool', () => {
     await recovery.expectContactItem('Carol');
   });
 
+  test('email addresses in contact list are mailto links', async ({ page }) => {
+    const bundleDir = extractBundle(bundlesDir, 'Alice');
+    const recovery = new RecoveryPage(page, bundleDir);
+
+    await recovery.open();
+
+    // Bob's email should be a tappable mailto: link
+    const bobContact = page.locator('.contact-item').filter({ hasText: 'Bob' }).locator('.contact-info a');
+    await expect(bobContact).toHaveAttribute('href', 'mailto:bob@test.com');
+    await expect(bobContact).toHaveText('bob@test.com');
+  });
+
   test('contact list updates when shares are collected', async ({ page }) => {
     const [aliceDir, bobDir] = extractBundles(bundlesDir, ['Alice', 'Bob']);
     const recovery = new RecoveryPage(page, aliceDir);

--- a/internal/html/assets/src/app.ts
+++ b/internal/html/assets/src/app.ts
@@ -18,6 +18,15 @@ declare const t: TranslationFunction;
   // Import shared utilities
   const { escapeHtml, formatSize, toast, showInlineError, clearInlineError } = window.rememoryUtils;
 
+  // Wrap email addresses in mailto: links. Input must already be HTML-escaped.
+  const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+  function linkifyEmail(escaped: string): string {
+    return escaped.replace(EMAIL_RE, (match) => {
+      const clean = match.replace(/\.+$/, '');
+      return `<a href="mailto:${clean}">${clean}</a>`;
+    });
+  }
+
   // State
   const state: RecoveryState = {
     shares: [],
@@ -328,7 +337,7 @@ declare const t: TranslationFunction;
         item.dataset.shareIndex = String(friend.shareIndex);
       }
 
-      const contactInfo = friend.contact ? escapeHtml(friend.contact) : '';
+      const contactInfo = friend.contact ? linkifyEmail(escapeHtml(friend.contact)) : '';
 
       item.innerHTML = `
         <div class="checkbox"></div>


### PR DESCRIPTION
Wraps email addresses in the contact list with `mailto:` links, making them tappable on phones rather than requiring copy-paste. Strips trailing dots from matches to handle emails in prose (e.g. `user@example.com.`).

The CSS for `.contact-info a` was already in place — this adds the JS to match.

Closes #62