### PR TITLE
fix: error when sealing untouched template README

### DIFF
--- a/internal/cmd/demo.go
+++ b/internal/cmd/demo.go
@@ -71,12 +71,7 @@ func runDemo(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write the manifest README template
-	templateData := project.TemplateData{
-		ProjectName: "Demo Project",
-		Friends:     friends,
-		Threshold:   threshold,
-	}
-	if err := project.WriteManifestReadme(p.ManifestPath(), templateData); err != nil {
+	if err := project.WriteManifestReadme(p.ManifestPath(), project.TemplateDataFromProject(p)); err != nil {
 		return fmt.Errorf("creating manifest README: %w", err)
 	}
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -267,12 +267,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write the manifest README template
-	templateData := project.TemplateData{
-		ProjectName: name,
-		Friends:     friends,
-		Threshold:   threshold,
-	}
-	if err := project.WriteManifestReadme(p.ManifestPath(), templateData); err != nil {
+	if err := project.WriteManifestReadme(p.ManifestPath(), project.TemplateDataFromProject(p)); err != nil {
 		return fmt.Errorf("creating manifest README: %w", err)
 	}
 

--- a/internal/cmd/seal.go
+++ b/internal/cmd/seal.go
@@ -90,6 +90,26 @@ func sealProject(p *project.Project, recoveryURL string, noEmbedManifest bool) e
 		return fmt.Errorf("manifest directory is empty: %s", manifestDir)
 	}
 
+	// Detect untouched template: exactly one file in the manifest tree,
+	// a README.md exists at the root, and its contents match the rendered template.
+	if fileCount == 1 {
+		readmePath := filepath.Join(manifestDir, "README.md")
+		actual, err := os.ReadFile(readmePath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("reading manifest file: %w", err)
+		}
+		if err == nil {
+			td := project.TemplateDataFromProject(p)
+			expected, err := project.RenderManifestReadme(td)
+			if err != nil {
+				return fmt.Errorf("rendering manifest template: %w", err)
+			}
+			if bytes.Equal(actual, expected) {
+				return fmt.Errorf("manifest contains only the template README — add your files to %s before sealing", manifestDir)
+			}
+		}
+	}
+
 	dirSize, err := manifest.DirSize(manifestDir)
 	if err != nil {
 		return fmt.Errorf("calculating manifest size: %w", err)

--- a/internal/project/templates.go
+++ b/internal/project/templates.go
@@ -21,23 +21,36 @@ type TemplateData struct {
 
 // WriteManifestReadme creates the README.md file in the manifest directory.
 func WriteManifestReadme(manifestDir string, data TemplateData) error {
+	content, err := RenderManifestReadme(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(manifestDir, "README.md"), content, 0644)
+}
+
+// TemplateDataFromProject builds TemplateData from a Project.
+func TemplateDataFromProject(p *Project) TemplateData {
+	return TemplateData{
+		ProjectName: p.Name,
+		Friends:     p.Friends,
+		Threshold:   p.Threshold,
+	}
+}
+
+// RenderManifestReadme renders the manifest README template to bytes.
+// Used at seal time to detect an untouched template.
+func RenderManifestReadme(data TemplateData) ([]byte, error) {
 	tmpl, err := template.New("readme").Parse(manifestReadmeTemplate)
 	if err != nil {
-		return fmt.Errorf("parsing template: %w", err)
+		return nil, fmt.Errorf("parsing template: %w", err)
 	}
 
-	path := filepath.Join(manifestDir, "README.md")
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("creating README.md: %w", err)
-	}
-	defer f.Close()
-
-	if err := tmpl.Execute(f, data); err != nil {
-		return fmt.Errorf("executing template: %w", err)
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("executing template: %w", err)
 	}
 
-	return nil
+	return []byte(buf.String()), nil
 }
 
 // FriendNames returns a comma-separated list of friend names.


### PR DESCRIPTION
Summary

- Detect when the manifest contains only the original template README and error instead of creating a useless encrypted bundle
- Three conditions (all must be true): exactly one file in the manifest tree, a `README.md` exists at the root, contents match the re-rendered template byte-for-byte
- Refactored `WriteManifestReadme` to use a new `RenderManifestReadme` (render to bytes), eliminating template duplication
- Consolidated `TemplateData` construction in `init`, `demo`, and `seal` through `TemplateDataFromProject`

Closes #61

Test plan

- [x] `make lint` passes
- [x] `make test` passes (all existing tests, including `TestWriteManifestReadme` which now implicitly covers `RenderManifestReadme`)
- [ ] Manual: `rememory init`, then `rememory seal` without adding files — should error
- [ ] Manual: `rememory init`, edit README.md (even a trailing newline), then `rememory seal` — should proceed
- [ ] Manual: `rememory init`, add a file to manifest/, then `rememory seal` — should proceed