### PR TITLE
fix: download recovered files as .zip instead of .tar.gz

### DIFF
--- a/internal/html/assets/src/app.ts
+++ b/internal/html/assets/src/app.ts
@@ -23,6 +23,7 @@ import {
   bytesToBase64,
   decrypt,
   extractTarGz,
+  createZip,
   extractBundle,
   extractPersonalizationFromHTML,
   decodeShareWords,
@@ -1117,10 +1118,9 @@ type UIShare = ParsedShare & { isHolder?: boolean };
 
       setProgress(60);
 
-      state.decryptedArchive = decrypted;
-
       setStatus(t('reading'));
       const files = await extractTarGz(decrypted);
+      state.extractedFiles = files;
 
       setProgress(90);
 
@@ -1189,13 +1189,14 @@ type UIShare = ParsedShare & { isHolder?: boolean };
   // ============================================
 
   function downloadAll(): void {
-    if (!state.decryptedArchive) return;
+    if (!state.extractedFiles || state.extractedFiles.length === 0) return;
 
-    const blob = new Blob([state.decryptedArchive as BlobPart], { type: 'application/gzip' });
+    const zipData = createZip(state.extractedFiles);
+    const blob = new Blob([zipData], { type: 'application/zip' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'manifest.tar.gz';
+    a.download = 'manifest.zip';
     a.click();
     URL.revokeObjectURL(url);
 
@@ -1203,7 +1204,7 @@ type UIShare = ParsedShare & { isHolder?: boolean };
   }
 
   function clearSensitiveState(): void {
-    state.decryptedArchive = undefined;
+    state.extractedFiles = undefined;
     state.manifest = null;
   }
 

--- a/internal/html/assets/src/crypto/archive.ts
+++ b/internal/html/assets/src/crypto/archive.ts
@@ -1,5 +1,7 @@
 // Tar.gz extraction using tarparser
 import { parseTar } from 'tarparser';
+// ZIP creation using fflate
+import { zipSync } from 'fflate';
 
 export interface ExtractedFile {
   name: string;
@@ -18,4 +20,16 @@ export async function extractTarGz(data: Uint8Array): Promise<ExtractedFile[]> {
       name: entry.name,
       data: entry.data,
     }));
+}
+
+/**
+ * Create a ZIP archive from an array of files.
+ */
+export function createZip(files: ExtractedFile[]): Uint8Array<ArrayBuffer> {
+  const input: Record<string, Uint8Array> = {};
+  for (const f of files) {
+    input[f.name] = f.data;
+  }
+  // zipSync always returns a Uint8Array backed by a plain ArrayBuffer at runtime
+  return zipSync(input) as unknown as Uint8Array<ArrayBuffer>;
 }

--- a/internal/html/assets/src/crypto/index.ts
+++ b/internal/html/assets/src/crypto/index.ts
@@ -3,7 +3,7 @@
 export { sha256, hashBytes, verifyHash } from './hash';
 export { combine, recoverPassphrase, base64ToBytes, bytesToBase64 } from './shamir';
 export { decrypt } from './age';
-export { extractTarGz, type ExtractedFile } from './archive';
+export { extractTarGz, createZip, type ExtractedFile } from './archive';
 export { parseShare, parseCompactShare, encodeCompact, type ParsedShare } from './share';
 export {
   decodeShareWords,

--- a/internal/html/assets/src/types.ts
+++ b/internal/html/assets/src/types.ts
@@ -85,7 +85,7 @@ export interface RecoveryState {
   total: number;
   recovering: boolean;
   recoveryComplete: boolean;
-  decryptedArchive?: Uint8Array;
+  extractedFiles?: Array<{ name: string; data: Uint8Array }>;
 }
 
 export interface CreationState {

--- a/internal/translations/recover/de.json
+++ b/internal/translations/recover/de.json
@@ -11,7 +11,7 @@
   "step2_hint": "Verwende eine recover.html aus dem Paket eines Freundes oder die MANIFEST.age-Datei",
   "step3_title": "Dateien wiederherstellen",
   "decrypt_btn": "Entsperren & Wiederherstellen",
-  "download_btn": "Archiv herunterladen (.tar.gz)",
+  "download_btn": "Archiv herunterladen (.zip)",
   "no_manifest": "Noch kein Archiv geladen",
   "works_offline": "Funktioniert komplett offline",
   "need_help": "Brauchst du Hilfe?",

--- a/internal/translations/recover/en.json
+++ b/internal/translations/recover/en.json
@@ -11,7 +11,7 @@
   "step2_hint": "Use a recover.html from any friend's bundle, or the MANIFEST.age file",
   "step3_title": "Recover the files",
   "decrypt_btn": "Unlock & Recover",
-  "download_btn": "Download archive (.tar.gz)",
+  "download_btn": "Download archive (.zip)",
   "no_manifest": "No archive added yet",
   "works_offline": "Works fully offline",
   "need_help": "Need help?",

--- a/internal/translations/recover/es.json
+++ b/internal/translations/recover/es.json
@@ -11,7 +11,7 @@
   "step2_hint": "Puedes usar un recover.html del kit de cualquier amigo, o el archivo MANIFEST.age",
   "step3_title": "Recuperar los archivos",
   "decrypt_btn": "Desbloquear y recuperar",
-  "download_btn": "Descargar el archivo (.tar.gz)",
+  "download_btn": "Descargar el archivo (.zip)",
   "no_manifest": "Aún no se ha subido ningún archivo",
   "works_offline": "Funciona completamente sin internet",
   "need_help": "¿Necesitas ayuda?",

--- a/internal/translations/recover/fr.json
+++ b/internal/translations/recover/fr.json
@@ -11,7 +11,7 @@
   "step2_hint": "Utilisez un recover.html de l'enveloppe d'un ami, ou le fichier MANIFEST.age",
   "step3_title": "Récupérer les fichiers",
   "decrypt_btn": "Déverrouiller et récupérer",
-  "download_btn": "Télécharger l'archive (.tar.gz)",
+  "download_btn": "Télécharger l'archive (.zip)",
   "no_manifest": "Aucune archive ajoutée pour le moment",
   "works_offline": "Fonctionne entièrement hors ligne",
   "need_help": "Besoin d'aide ?",

--- a/internal/translations/recover/pt.json
+++ b/internal/translations/recover/pt.json
@@ -11,7 +11,7 @@
   "step2_hint": "Você pode usar um recover.html de qualquer pacote de amigo, ou o arquivo MANIFEST.age",
   "step3_title": "Recupere os arquivos",
   "decrypt_btn": "Desbloquear & Recuperar",
-  "download_btn": "Baixar o arquivo (.tar.gz)",
+  "download_btn": "Baixar o arquivo (.zip)",
   "no_manifest": "Nenhum arquivo adicionado ainda",
   "works_offline": "Isso funciona completamente offline",
   "need_help": "Precisa de ajuda?",

--- a/internal/translations/recover/sl.json
+++ b/internal/translations/recover/sl.json
@@ -11,7 +11,7 @@
   "step2_hint": "Uporabite recover.html iz svežnja kateregakoli prijatelja ali datoteko MANIFEST.age",
   "step3_title": "Obnovljene datoteke",
   "decrypt_btn": "Odkleni in obnovi",
-  "download_btn": "Prenesi arhiv (.tar.gz)",
+  "download_btn": "Prenesi arhiv (.zip)",
   "no_manifest": "Arhiv še ni dodan",
   "works_offline": "Deluje popolnoma brez povezave",
   "need_help": "Potrebujete pomoč?",

--- a/internal/translations/recover/zh-TW.json
+++ b/internal/translations/recover/zh-TW.json
@@ -11,7 +11,7 @@
   "step2_hint": "使用任何一位朋友的復原包裡的 recover.html 或 MANIFEST.age",
   "step3_title": "復原檔案",
   "decrypt_btn": "解鎖及復原",
-  "download_btn": "下載封存檔（.tar.gz）",
+  "download_btn": "下載封存檔（.zip）",
   "no_manifest": "未加入封存檔",
   "works_offline": "可完全離線使用",
   "need_help": "需要幫助？",


### PR DESCRIPTION
## Summary

- Recovered files now download as `manifest.zip` instead of `manifest.tar.gz`
- ZIP opens natively on Windows, Android, and iOS — no third-party software needed
- Uses `fflate` (already bundled) for zip creation; no new dependencies
- All 7 language translations updated

## How it works

After decryption, files are already extracted into memory as `ExtractedFile[]`. The new `createZip()` function in the native crypto module uses `fflate.zipSync` to pack them into a ZIP before the browser download.

`RecoveryState.decryptedArchive` (raw encrypted bytes) is replaced by `extractedFiles` (the extracted file list), which is cleaner — the download step now works with the files the user actually wants, not a compressed archive format.

## Test plan

- [ ] Run `make test` — all Go tests pass
- [ ] Run `make lint` — TypeScript and Go lint clean
- [ ] Manually test recovery in browser: complete a recovery and verify the download button produces a `.zip` that opens correctly on Windows/macOS/iOS

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)