### PR TITLE
feat: embed recovery guide in recover.html

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -82,6 +82,28 @@ func GenerateAll(p *project.Project, cfg Config) error {
 			}
 		}
 
+		// Embed manifest in recover.html when small enough and not disabled
+		manifestEmbedded := !cfg.NoEmbedManifest && len(manifestData) <= html.MaxEmbeddedManifestSize
+
+		// Pre-generate README text to embed in recover.html as an in-page guide.
+		// RecoverChecksum is omitted here (not yet computed); users can't verify it from inside the file.
+		guideReadmeData := ReadmeData{
+			ProjectName:      p.Name,
+			Holder:           friend.Name,
+			Share:            share,
+			OtherFriends:     otherFriends,
+			Threshold:        p.Threshold,
+			Total:            len(p.Friends),
+			Version:          cfg.Version,
+			GitHubReleaseURL: cfg.GitHubReleaseURL,
+			ManifestChecksum: manifestChecksum,
+			Created:          p.Sealed.At,
+			Anonymous:        p.Anonymous,
+			Language:         lang,
+			ManifestEmbedded: manifestEmbedded,
+		}
+		guideText := GenerateReadme(guideReadmeData)
+
 		// Generate personalized recover.html for this friend
 		personalization := &html.PersonalizationData{
 			Holder:       friend.Name,
@@ -90,10 +112,10 @@ func GenerateAll(p *project.Project, cfg Config) error {
 			Threshold:    p.Threshold,
 			Total:        len(p.Friends),
 			Language:     lang,
+			ProjectName:  p.Name,
+			ReadmeText:   guideText,
 		}
 
-		// Embed manifest in recover.html when small enough and not disabled
-		manifestEmbedded := !cfg.NoEmbedManifest && len(manifestData) <= html.MaxEmbeddedManifestSize
 		if manifestEmbedded {
 			personalization.ManifestB64 = base64.StdEncoding.EncodeToString(manifestData)
 		}

--- a/internal/html/assets/recover.html
+++ b/internal/html/assets/recover.html
@@ -12,6 +12,20 @@
   <!-- Toast notifications container -->
   <div id="toast-container" class="toast-container" role="alert" aria-live="polite"></div>
 
+  <!-- Guide modal (shown when personalized recover.html has embedded guide) -->
+  <div id="guide-modal" class="guide-modal hidden" role="dialog" aria-modal="true" aria-labelledby="guide-modal-title">
+    <div class="guide-modal-content">
+      <div class="guide-modal-header">
+        <h2 id="guide-modal-title" data-i18n="guide_title">Your recovery guide</h2>
+        <div class="guide-modal-actions">
+          <button id="guide-download-btn" class="btn btn-secondary btn-sm" type="button" data-i18n="guide_download">Save as .txt</button>
+          <button id="guide-close-btn" class="btn btn-secondary btn-sm" type="button" data-i18n="guide_close">Close</button>
+        </div>
+      </div>
+      <pre id="guide-content" class="guide-content"></pre>
+    </div>
+  </div>
+
   <!-- QR Scanner modal -->
   <div id="qr-scanner-modal" class="qr-scanner-modal hidden" role="dialog" aria-modal="true" aria-label="QR code scanner">
     <div class="qr-scanner-header">
@@ -38,6 +52,7 @@
       </div>
       <div class="nav-links hidden" id="nav-links-bundle">
         <a href="{{GITHUB_PAGES}}/docs" target="_blank" data-i18n="nav_guide">Guide</a>
+        <button id="guide-btn" class="btn-link hidden" type="button" data-i18n="guide_btn">Your guide</button>
       </div>
       <select class="lang-select" id="lang-select" aria-label="Language">
         {{LANG_OPTIONS}}

--- a/internal/html/assets/src/app.ts
+++ b/internal/html/assets/src/app.ts
@@ -88,6 +88,11 @@ type UIShare = ParsedShare & { isHolder?: boolean };
     qrScannerModal: HTMLElement | null;
     qrVideo: HTMLVideoElement | null;
     qrScannerClose: HTMLButtonElement | null;
+    guideBtn: HTMLButtonElement | null;
+    guideModal: HTMLElement | null;
+    guideContent: HTMLElement | null;
+    guideCloseBtn: HTMLButtonElement | null;
+    guideDownloadBtn: HTMLButtonElement | null;
   }
 
   // DOM elements
@@ -118,6 +123,11 @@ type UIShare = ParsedShare & { isHolder?: boolean };
     qrScannerModal: document.getElementById('qr-scanner-modal'),
     qrVideo: document.getElementById('qr-video') as HTMLVideoElement | null,
     qrScannerClose: document.getElementById('qr-scanner-close') as HTMLButtonElement | null,
+    guideBtn: document.getElementById('guide-btn') as HTMLButtonElement | null,
+    guideModal: document.getElementById('guide-modal'),
+    guideContent: document.getElementById('guide-content'),
+    guideCloseBtn: document.getElementById('guide-close-btn') as HTMLButtonElement | null,
+    guideDownloadBtn: document.getElementById('guide-download-btn') as HTMLButtonElement | null,
   };
 
   // Personalization data (embedded in HTML)
@@ -256,6 +266,7 @@ type UIShare = ParsedShare & { isHolder?: boolean };
     // Load personalization data
     if (personalization) {
       await loadPersonalizationData();
+      initGuide();
     }
 
     // Check URL fragment for compact share (e.g. #share=RM1:2:5:3:BASE64:CHECK)
@@ -1062,6 +1073,17 @@ type UIShare = ParsedShare & { isHolder?: boolean };
   function setupButtons(): void {
     elements.recoverBtn?.addEventListener('click', startRecovery);
     elements.downloadAllBtn?.addEventListener('click', downloadAll);
+    elements.guideBtn?.addEventListener('click', showGuide);
+    elements.guideCloseBtn?.addEventListener('click', hideGuide);
+    elements.guideDownloadBtn?.addEventListener('click', downloadGuide);
+    elements.guideModal?.addEventListener('click', (e: MouseEvent) => {
+      if (e.target === elements.guideModal) hideGuide();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && elements.guideModal && !elements.guideModal.classList.contains('hidden')) {
+        hideGuide();
+      }
+    });
   }
 
   function checkRecoverReady(): void {
@@ -1182,6 +1204,41 @@ type UIShare = ParsedShare & { isHolder?: boolean };
       elements.statusMessage.textContent = msg;
       elements.statusMessage.className = 'status-message' + (type ? ' ' + type : '');
     }
+  }
+
+  // ============================================
+  // Guide
+  // ============================================
+
+  function initGuide(): void {
+    if (!personalization?.readmeText) return;
+    elements.guideBtn?.classList.remove('hidden');
+    if (elements.guideContent) {
+      elements.guideContent.textContent = personalization.readmeText;
+    }
+  }
+
+  function showGuide(): void {
+    elements.guideModal?.classList.remove('hidden');
+    elements.guideCloseBtn?.focus();
+  }
+
+  function hideGuide(): void {
+    elements.guideModal?.classList.add('hidden');
+    elements.guideBtn?.focus();
+  }
+
+  function downloadGuide(): void {
+    if (!personalization?.readmeText) return;
+    const holder = personalization.holder || 'guide';
+    const filename = `README-${holder.replace(/[^a-z0-9]/gi, '_')}.txt`;
+    const blob = new Blob([personalization.readmeText], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
   }
 
   // ============================================

--- a/internal/html/assets/src/types.ts
+++ b/internal/html/assets/src/types.ts
@@ -69,6 +69,8 @@ export interface PersonalizationData {
   total: number;
   language?: string;
   manifestB64?: string; // Base64-encoded MANIFEST.age (when small enough to embed)
+  projectName?: string; // Project name for display in guide
+  readmeText?: string;  // Pre-generated README for the in-page guide
 }
 
 // ============================================

--- a/internal/html/assets/styles.css
+++ b/internal/html/assets/styles.css
@@ -1175,3 +1175,85 @@ footer a:hover {
     margin-left: 0;
   }
 }
+
+/* ============================================
+   Guide Modal
+   ============================================ */
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--dusty-blue);
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.btn-link:hover {
+  color: var(--dusty-blue-dark);
+}
+
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.guide-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(46, 42, 38, 0.55);
+  z-index: 1400;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+  overflow-y: auto;
+}
+
+.guide-modal-content {
+  background: var(--paper-light);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+}
+
+.guide-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-light);
+  gap: 1rem;
+}
+
+.guide-modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text);
+}
+
+.guide-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.guide-content {
+  padding: 1.25rem;
+  margin: 0;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  max-height: 70vh;
+  overflow-y: auto;
+}

--- a/internal/html/recover.go
+++ b/internal/html/recover.go
@@ -32,6 +32,8 @@ type PersonalizationData struct {
 	Total        int          `json:"total"`                 // Total shares (N)
 	Language     string       `json:"language,omitempty"`    // Default UI language for this friend
 	ManifestB64  string       `json:"manifestB64,omitempty"` // Base64-encoded MANIFEST.age (when <= MaxEmbeddedManifestSize)
+	ProjectName  string       `json:"projectName,omitempty"` // Project name for display in the guide
+	ReadmeText   string       `json:"readmeText,omitempty"`  // Pre-generated README text for the in-page guide
 }
 
 // GenerateRecoverHTML creates the complete recover.html with all assets embedded.

--- a/internal/translations/recover/de.json
+++ b/internal/translations/recover/de.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Andere Teile probieren",
   "nav_about": "Über",
   "nav_create": "Erstellen",
-  "nav_guide": "Anleitung"
+  "nav_guide": "Anleitung",
+  "guide_btn": "Deine Anleitung",
+  "guide_title": "Deine Wiederherstellungsanleitung",
+  "guide_close": "Schließen",
+  "guide_download": "Als .txt speichern"
 }

--- a/internal/translations/recover/en.json
+++ b/internal/translations/recover/en.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Try different pieces",
   "nav_about": "About",
   "nav_create": "Create Bundles",
-  "nav_guide": "Guide"
+  "nav_guide": "Guide",
+  "guide_btn": "Your guide",
+  "guide_title": "Your recovery guide",
+  "guide_close": "Close",
+  "guide_download": "Save as .txt"
 }

--- a/internal/translations/recover/es.json
+++ b/internal/translations/recover/es.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Probar otras partes",
   "nav_about": "Acerca de",
   "nav_create": "Crear kits",
-  "nav_guide": "Manual"
+  "nav_guide": "Manual",
+  "guide_btn": "Tu guía",
+  "guide_title": "Tu guía de recuperación",
+  "guide_close": "Cerrar",
+  "guide_download": "Guardar como .txt"
 }

--- a/internal/translations/recover/fr.json
+++ b/internal/translations/recover/fr.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Essayer d'autres parts",
   "nav_about": "À propos",
   "nav_create": "Créer",
-  "nav_guide": "Guide"
+  "nav_guide": "Guide",
+  "guide_btn": "Votre guide",
+  "guide_title": "Votre guide de récupération",
+  "guide_close": "Fermer",
+  "guide_download": "Enregistrer en .txt"
 }

--- a/internal/translations/recover/pt.json
+++ b/internal/translations/recover/pt.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Tentar partes diferentes",
   "nav_about": "Sobre",
   "nav_create": "Criar pacotes",
-  "nav_guide": "Guia"
+  "nav_guide": "Guia",
+  "guide_btn": "Seu guia",
+  "guide_title": "Seu guia de recuperação",
+  "guide_close": "Fechar",
+  "guide_download": "Salvar como .txt"
 }

--- a/internal/translations/recover/sl.json
+++ b/internal/translations/recover/sl.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "Poskusi druge dele",
   "nav_about": "O projektu",
   "nav_create": "Ustvari",
-  "nav_guide": "Vodič"
+  "nav_guide": "Vodič",
+  "guide_btn": "Tvoj vodič",
+  "guide_title": "Tvoj vodič za obnovitev",
+  "guide_close": "Zapri",
+  "guide_download": "Shrani kot .txt"
 }

--- a/internal/translations/recover/zh-TW.json
+++ b/internal/translations/recover/zh-TW.json
@@ -85,5 +85,9 @@
   "action_try_different_shares": "嘗試不同的金鑰片段",
   "nav_about": "關於",
   "nav_create": "建立復原包",
-  "nav_guide": "指南"
+  "nav_guide": "指南",
+  "guide_btn": "你的指南",
+  "guide_title": "你的復原指南",
+  "guide_close": "關閉",
+  "guide_download": "儲存為 .txt"
 }

--- a/internal/wasm/create.go
+++ b/internal/wasm/create.go
@@ -253,6 +253,28 @@ func createBundles(config CreateBundlesConfig) ([]BundleOutput, error) {
 			}
 		}
 
+		// Embed manifest in recover.html when small enough
+		manifestEmbedded := len(manifestData) <= html.MaxEmbeddedManifestSize
+
+		// Pre-generate README text to embed in recover.html as an in-page guide.
+		// RecoverChecksum is omitted here (not yet computed); users can't verify it from inside the file.
+		guideReadmeData := bundle.ReadmeData{
+			ProjectName:      config.ProjectName,
+			Holder:           friend.Name,
+			Share:            share,
+			OtherFriends:     otherFriends,
+			Threshold:        k,
+			Total:            n,
+			Version:          config.Version,
+			GitHubReleaseURL: config.GitHubURL,
+			ManifestChecksum: manifestChecksum,
+			Created:          now,
+			Anonymous:        config.Anonymous,
+			Language:         lang,
+			ManifestEmbedded: manifestEmbedded,
+		}
+		guideText := bundle.GenerateReadme(guideReadmeData)
+
 		// Generate personalized recover.html
 		personalization := &html.PersonalizationData{
 			Holder:       friend.Name,
@@ -261,10 +283,10 @@ func createBundles(config CreateBundlesConfig) ([]BundleOutput, error) {
 			Threshold:    k,
 			Total:        n,
 			Language:     lang,
+			ProjectName:  config.ProjectName,
+			ReadmeText:   guideText,
 		}
 
-		// Embed manifest in recover.html when small enough
-		manifestEmbedded := len(manifestData) <= html.MaxEmbeddedManifestSize
 		if manifestEmbedded {
 			personalization.ManifestB64 = base64.StdEncoding.EncodeToString(manifestData)
 		}


### PR DESCRIPTION
## Summary

- Personalized `recover.html` files now contain a complete copy of the recovery guide
- A **"Your guide"** link appears in the navigation bar of personalized bundles
- Clicking it opens a modal with the full guide — the same content as `README.txt` and `README.pdf`
- A **"Save as .txt"** button lets anyone download it for printing or offline storage
- All 7 languages supported

## Why

Someone who saved only their `recover.html` can now read the complete instructions for how to contribute their piece, who to contact, and how to open the recovery tool — without needing the separate README files from the bundle.

## How it works

The README text is pre-generated on the Go side (both CLI and WASM/maker.html paths) and embedded in the personalization JSON inside `recover.html`. The guide omits the `recover.html`'s own checksum (which users can't verify from inside the file), but includes all other content: project context, the warning, contact list, recovery steps, share words, and PEM block.

On the browser side, a guide modal with `<pre>` rendering shows the text. The "Save as .txt" button creates a Blob download named `README-{holder}.txt`.

## Test plan

- [ ] `make test` — all Go tests pass
- [ ] `make lint` — TypeScript and Go lint clean
- [ ] Generate demo bundles (`rememory demo`) and verify:
  - "Your guide" link appears in the personalized `recover.html` nav
  - Modal opens and shows the complete guide text
  - "Save as .txt" downloads a readable file named after the holder
  - Generic `recover.html` (no personalization) shows no guide link

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)