### PR TITLE
Allow ZIP files to be passed as cli arguments for recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to ReMemory are documented here.
 ## Unreleased
 
 - **ZIP archive format** — Encrypted payloads now use ZIP instead of tar.gz. ZIP is understood by every operating system without extra tools, which makes manual inspection easier if someone ever needs it. Existing bundles created with earlier versions still work — the recovery tool detects the format automatically.
+- **Recover directly from bundles** — `rememory recover` now accepts bundle ZIP files. You can pass the ZIPs your friends send you without unzipping them first, and the manifest is extracted automatically. `rememory recover bundle-alice.zip bundle-bob.zip` just works.
 
 ## v0.0.14 — 2026-02-19
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -376,10 +376,13 @@ If the browser tool doesn't work:
 
 ```bash
 # Download rememory from GitHub releases, then:
-rememory recover \
-  --shares alice-readme.txt,bob-readme.txt,carol-readme.txt \
-  --manifest MANIFEST.age \
-  --output recovered/
+rememory recover bundle-alice.zip bundle-bob.zip bundle-carol.zip
+```
+
+You can also pass extracted share files and a manifest separately:
+
+```bash
+rememory recover SHARE-alice.txt SHARE-bob.txt SHARE-carol.txt -m MANIFEST.age
 ```
 
 ## Verifying Bundles

--- a/internal/bundle/extract.go
+++ b/internal/bundle/extract.go
@@ -1,0 +1,106 @@
+package bundle
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+
+	"github.com/eljojo/rememory/internal/core"
+	"github.com/eljojo/rememory/internal/html"
+	"github.com/eljojo/rememory/internal/translations"
+)
+
+// ExtractShareFromZip opens a bundle ZIP and parses the share from the
+// README.txt inside it.
+func ExtractShareFromZip(zipPath string) (*core.Share, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening zip: %w", err)
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if !translations.IsReadmeFile(f.Name, ".txt") {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("opening %s in zip: %w", f.Name, err)
+		}
+
+		data, err := io.ReadAll(rc)
+		if closeErr := rc.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading %s from zip: %w", f.Name, err)
+		}
+
+		share, err := core.ParseShare(data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing share from %s: %w", f.Name, err)
+		}
+
+		return share, nil
+	}
+
+	return nil, fmt.Errorf("no README file (.txt) found in zip")
+}
+
+// ExtractManifestFromZip opens a bundle ZIP and extracts the encrypted
+// manifest data. It looks for MANIFEST.age first. If not found, it falls
+// back to extracting the manifest embedded in recover.html.
+func ExtractManifestFromZip(zipPath string) ([]byte, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening zip: %w", err)
+	}
+	defer r.Close()
+
+	var recoverData []byte
+
+	for _, f := range r.File {
+		switch {
+		case f.Name == "MANIFEST.age":
+			rc, err := f.Open()
+			if err != nil {
+				return nil, fmt.Errorf("opening MANIFEST.age in zip: %w", err)
+			}
+
+			data, err := io.ReadAll(rc)
+			if closeErr := rc.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return nil, fmt.Errorf("reading MANIFEST.age from zip: %w", err)
+			}
+			return data, nil
+
+		case f.Name == "recover.html":
+			rc, err := f.Open()
+			if err != nil {
+				return nil, fmt.Errorf("opening recover.html in zip: %w", err)
+			}
+
+			recoverData, err = io.ReadAll(rc)
+			if closeErr := rc.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return nil, fmt.Errorf("reading recover.html from zip: %w", err)
+			}
+		}
+	}
+
+	// Fall back to extracting manifest from recover.html personalization data
+	if len(recoverData) > 0 {
+		manifest, err := html.ExtractManifestFromHTML(recoverData)
+		if err != nil {
+			return nil, fmt.Errorf("extracting manifest from recover.html in zip: %w", err)
+		}
+		return manifest, nil
+	}
+
+	return nil, fmt.Errorf("no MANIFEST.age or recover.html found in zip")
+}

--- a/internal/bundle/extract_test.go
+++ b/internal/bundle/extract_test.go
@@ -1,0 +1,187 @@
+package bundle
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eljojo/rememory/internal/core"
+)
+
+func testShare() *core.Share {
+	return core.NewShare(2, 1, 3, 2, "Alice", []byte("test-share-data"))
+}
+
+func TestExtractShareFromZip(t *testing.T) {
+	share := testShare()
+	readme := fmt.Sprintf("Some instructions\n\n%s\nMore text", share.Encode())
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "README.txt", Content: []byte(readme), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	got, err := ExtractShareFromZip(zipPath)
+	if err != nil {
+		t.Fatalf("ExtractShareFromZip: %v", err)
+	}
+
+	if got.Index != share.Index {
+		t.Errorf("index: got %d, want %d", got.Index, share.Index)
+	}
+	if got.Total != share.Total {
+		t.Errorf("total: got %d, want %d", got.Total, share.Total)
+	}
+	if got.Threshold != share.Threshold {
+		t.Errorf("threshold: got %d, want %d", got.Threshold, share.Threshold)
+	}
+	if got.Holder != share.Holder {
+		t.Errorf("holder: got %q, want %q", got.Holder, share.Holder)
+	}
+}
+
+func TestExtractShareFromZip_LocalizedReadme(t *testing.T) {
+	share := testShare()
+	readme := share.Encode()
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "LEEME.txt", Content: []byte(readme), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	got, err := ExtractShareFromZip(zipPath)
+	if err != nil {
+		t.Fatalf("ExtractShareFromZip: %v", err)
+	}
+
+	if got.Index != share.Index {
+		t.Errorf("index: got %d, want %d", got.Index, share.Index)
+	}
+}
+
+func TestExtractShareFromZip_NoReadme(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "recover.html", Content: []byte("<html></html>"), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	_, err = ExtractShareFromZip(zipPath)
+	if err == nil {
+		t.Fatal("expected error for zip without README.txt")
+	}
+}
+
+func TestExtractShareFromZip_NotAZip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-zip.zip")
+	if err := writeTestFile(path, []byte("not a zip")); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	_, err := ExtractShareFromZip(path)
+	if err == nil {
+		t.Fatal("expected error for non-zip file")
+	}
+}
+
+func TestExtractManifestFromZip_DirectManifest(t *testing.T) {
+	manifestData := []byte("encrypted-manifest-content")
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "MANIFEST.age", Content: manifestData, ModTime: time.Now()},
+		{Name: "recover.html", Content: []byte("<html></html>"), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	got, err := ExtractManifestFromZip(zipPath)
+	if err != nil {
+		t.Fatalf("ExtractManifestFromZip: %v", err)
+	}
+
+	if string(got) != string(manifestData) {
+		t.Errorf("manifest: got %q, want %q", got, manifestData)
+	}
+}
+
+func TestExtractManifestFromZip_EmbeddedInHTML(t *testing.T) {
+	manifestData := []byte("encrypted-manifest-content")
+	b64 := base64.StdEncoding.EncodeToString(manifestData)
+
+	personalization := map[string]interface{}{
+		"manifestB64": b64,
+		"share":       "test",
+	}
+	pJSON, _ := json.Marshal(personalization)
+	htmlContent := fmt.Sprintf(`<html><script>window.PERSONALIZATION = %s;</script></html>`, pJSON)
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "recover.html", Content: []byte(htmlContent), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	got, err := ExtractManifestFromZip(zipPath)
+	if err != nil {
+		t.Fatalf("ExtractManifestFromZip: %v", err)
+	}
+
+	if string(got) != string(manifestData) {
+		t.Errorf("manifest: got %q, want %q", got, manifestData)
+	}
+}
+
+func TestExtractManifestFromZip_NoManifest(t *testing.T) {
+	share := testShare()
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "README.txt", Content: []byte(share.Encode()), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	_, err = ExtractManifestFromZip(zipPath)
+	if err == nil {
+		t.Fatal("expected error for zip without manifest")
+	}
+}
+
+func TestExtractManifestFromZip_HTMLWithoutEmbeddedManifest(t *testing.T) {
+	// recover.html present but without embedded manifest (like --no-embed-manifest)
+	htmlContent := `<html><script>window.PERSONALIZATION = {"share":"test","manifestB64":""};</script></html>`
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	err := CreateZip(zipPath, []ZipFile{
+		{Name: "recover.html", Content: []byte(htmlContent), ModTime: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("creating zip: %v", err)
+	}
+
+	_, err = ExtractManifestFromZip(zipPath)
+	if err == nil {
+		t.Fatal("expected error for HTML without embedded manifest")
+	}
+}
+
+func writeTestFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0644)
+}

--- a/internal/cmd/recover.go
+++ b/internal/cmd/recover.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eljojo/rememory/internal/bundle"
 	"github.com/eljojo/rememory/internal/core"
 	"github.com/eljojo/rememory/internal/html"
 	"github.com/eljojo/rememory/internal/manifest"
@@ -15,15 +16,21 @@ import (
 )
 
 var recoverCmd = &cobra.Command{
-	Use:   "recover share1.txt share2.txt ... [--manifest MANIFEST.age]",
+	Use:   "recover [share1.txt|bundle1.zip] [share2.txt|bundle2.zip] ... [--manifest MANIFEST.age]",
 	Short: "Recover the manifest from shares",
 	Long: `Recover reconstructs the passphrase from shares and decrypts the manifest.
 
 This command can be run from anywhere (doesn't need a project directory).
 You need at least the threshold number of shares to recover.
 
+Shares can be plain text files, bundle ZIP files, or personalized
+recover.html files. The manifest is extracted from the first ZIP or
+HTML that contains one, unless --manifest is set.
+
 Example:
-  rememory recover SHARE-alice.txt SHARE-bob.txt SHARE-carol.txt -m MANIFEST.age`,
+  rememory recover bundle-alice.zip bundle-bob.zip
+  rememory recover alice/recover.html bob/recover.html carol/recover.html
+  rememory recover SHARE-alice.txt SHARE-bob.txt -m MANIFEST.age`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runRecover,
 }
@@ -36,7 +43,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(recoverCmd)
-	recoverCmd.Flags().StringVarP(&recoverManifest, "manifest", "m", "", "Path to MANIFEST.age file")
+	recoverCmd.Flags().StringVarP(&recoverManifest, "manifest", "m", "", "Path to MANIFEST.age file (or bundle .zip)")
 	recoverCmd.Flags().StringVarP(&recoverOutput, "output", "o", "", "Output directory (default: recovered-TIMESTAMP)")
 	recoverCmd.Flags().BoolVar(&recoverPassphrase, "passphrase-only", false, "Only output the passphrase, don't decrypt")
 }
@@ -47,14 +54,33 @@ func runRecover(cmd *cobra.Command, args []string) error {
 
 	shares := make([]*core.Share, len(args))
 	for i, path := range args {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("reading share %s: %w", path, err)
-		}
+		var share *core.Share
+		var err error
 
-		share, err := core.ParseShare(content)
-		if err != nil {
-			return fmt.Errorf("parsing share %s: %w", path, err)
+		if isZipFile(path) {
+			share, err = bundle.ExtractShareFromZip(path)
+			if err != nil {
+				return fmt.Errorf("extracting share from %s: %w", path, err)
+			}
+		} else if isHTMLFile(path) {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			share, err = html.ExtractShareFromHTML(content)
+			if err != nil {
+				return fmt.Errorf("extracting share from %s: %w", path, err)
+			}
+		} else {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading share %s: %w", path, err)
+			}
+
+			share, err = core.ParseShare(content)
+			if err != nil {
+				return fmt.Errorf("parsing share %s: %w", path, err)
+			}
 		}
 
 		// Verify checksum
@@ -120,37 +146,71 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Find manifest file
+	// Find manifest
+	var encryptedData []byte
 	manifestPath := recoverManifest
-	if manifestPath == "" {
-		// Try to find MANIFEST.age in current directory, then recover.html
-		if _, err := os.Stat("MANIFEST.age"); err == nil {
-			manifestPath = "MANIFEST.age"
-		} else if _, err := os.Stat("recover.html"); err == nil {
-			manifestPath = "recover.html"
-		} else {
-			return fmt.Errorf("MANIFEST.age not found in current directory; use --manifest to specify path\n  (you can also pass a personalized recover.html file)")
+
+	if manifestPath != "" && isZipFile(manifestPath) {
+		// --manifest points to a ZIP — extract from it
+		encryptedData, err = bundle.ExtractManifestFromZip(manifestPath)
+		if err != nil {
+			return fmt.Errorf("extracting manifest from %s: %w", manifestPath, err)
+		}
+		fmt.Printf("Extracted manifest from %s\n", manifestPath)
+	} else if manifestPath == "" {
+		// No --manifest flag — try extracting from the provided args
+		for _, path := range args {
+			if isZipFile(path) {
+				data, err := bundle.ExtractManifestFromZip(path)
+				if err == nil {
+					encryptedData = data
+					fmt.Printf("Extracted manifest from %s\n", path)
+					break
+				}
+			} else if isHTMLFile(path) {
+				content, err := os.ReadFile(path)
+				if err == nil {
+					data, err := html.ExtractManifestFromHTML(content)
+					if err == nil {
+						encryptedData = data
+						fmt.Printf("Extracted manifest from %s\n", path)
+						break
+					}
+				}
+			}
+		}
+
+		// Fall back to searching the current directory
+		if encryptedData == nil {
+			if _, err := os.Stat("MANIFEST.age"); err == nil {
+				manifestPath = "MANIFEST.age"
+			} else if _, err := os.Stat("recover.html"); err == nil {
+				manifestPath = "recover.html"
+			} else {
+				return fmt.Errorf("no manifest found — pass --manifest or include a bundle zip that contains one")
+			}
 		}
 	}
 
 	fmt.Println("Decrypting manifest...")
 
-	// Read manifest data — either directly from .age file or extracted from .html
-	var encryptedData []byte
-	if strings.HasSuffix(strings.ToLower(manifestPath), ".html") || strings.HasSuffix(strings.ToLower(manifestPath), ".htm") {
-		htmlContent, err := os.ReadFile(manifestPath)
-		if err != nil {
-			return fmt.Errorf("reading %s: %w", manifestPath, err)
-		}
-		encryptedData, err = html.ExtractManifestFromHTML(htmlContent)
-		if err != nil {
-			return fmt.Errorf("extracting manifest from %s: %w", manifestPath, err)
-		}
-		fmt.Printf("Extracted manifest from %s\n", manifestPath)
-	} else {
-		encryptedData, err = os.ReadFile(manifestPath)
-		if err != nil {
-			return fmt.Errorf("reading manifest: %w", err)
+	// Read manifest from file if not already extracted from a ZIP
+	if encryptedData == nil {
+		if strings.HasSuffix(strings.ToLower(manifestPath), ".html") || strings.HasSuffix(strings.ToLower(manifestPath), ".htm") {
+			htmlContent, err := os.ReadFile(manifestPath)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", manifestPath, err)
+			}
+			encryptedData, err = html.ExtractManifestFromHTML(htmlContent)
+			if err != nil {
+				return fmt.Errorf("extracting manifest from %s: %w", manifestPath, err)
+			}
+			fmt.Printf("Extracted manifest from %s\n", manifestPath)
+		} else {
+			encryptedData, err = os.ReadFile(manifestPath)
+			if err != nil {
+				return fmt.Errorf("reading manifest: %w", err)
+			}
 		}
 	}
 
@@ -200,4 +260,13 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func isZipFile(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".zip")
+}
+
+func isHTMLFile(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasSuffix(lower, ".html") || strings.HasSuffix(lower, ".htm")
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,7 +15,7 @@ using Shamir's Secret Sharing, and creates recovery bundles for trusted friends.
 
 Create a project:    rememory init my-recovery
 Seal the manifest:   rememory seal
-Recover from shares: rememory recover share1.txt share2.txt share3.txt`,
+Recover from shares: rememory recover bundle-alice.zip bundle-bob.zip`,
 }
 
 func Execute(v string) error {

--- a/internal/html/extract.go
+++ b/internal/html/extract.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+
+	"github.com/eljojo/rememory/internal/core"
 )
 
-// personalizationManifest is a minimal struct for extracting just the manifest
-// from the PERSONALIZATION JSON embedded in recover.html.
-type personalizationManifest struct {
+// personalizationExtract is a minimal struct for extracting the share and/or
+// manifest from the PERSONALIZATION JSON embedded in recover.html.
+type personalizationExtract struct {
+	HolderShare string `json:"holderShare"`
 	ManifestB64 string `json:"manifestB64"`
 }
 
@@ -32,7 +35,7 @@ func ExtractManifestFromHTML(htmlContent []byte) ([]byte, error) {
 		return nil, fmt.Errorf("no PERSONALIZATION data found in HTML")
 	}
 
-	var p personalizationManifest
+	var p personalizationExtract
 	if err := json.Unmarshal(matches[1], &p); err != nil {
 		return nil, fmt.Errorf("parsing PERSONALIZATION JSON: %w", err)
 	}
@@ -47,4 +50,29 @@ func ExtractManifestFromHTML(htmlContent []byte) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+// ExtractShareFromHTML extracts the share from a personalized recover.html file.
+// It finds the embedded PERSONALIZATION JSON and parses the holderShare field.
+func ExtractShareFromHTML(htmlContent []byte) (*core.Share, error) {
+	matches := personalizationRe.FindSubmatch(htmlContent)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("no PERSONALIZATION data found in HTML")
+	}
+
+	var p personalizationExtract
+	if err := json.Unmarshal(matches[1], &p); err != nil {
+		return nil, fmt.Errorf("parsing PERSONALIZATION JSON: %w", err)
+	}
+
+	if p.HolderShare == "" {
+		return nil, fmt.Errorf("no embedded share in HTML (holderShare is empty)")
+	}
+
+	share, err := core.ParseShare([]byte(p.HolderShare))
+	if err != nil {
+		return nil, fmt.Errorf("parsing share from HTML: %w", err)
+	}
+
+	return share, nil
 }

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -668,66 +668,20 @@ func TestBundleRecovery(t *testing.T) {
 
 func extractShareFromBundle(t *testing.T, bundlePath string) *core.Share {
 	t.Helper()
-
-	r, err := zip.OpenReader(bundlePath)
+	share, err := bundle.ExtractShareFromZip(bundlePath)
 	if err != nil {
-		t.Fatalf("opening bundle: %v", err)
+		t.Fatalf("extracting share from %s: %v", bundlePath, err)
 	}
-	defer r.Close()
-
-	for _, f := range r.File {
-		if translations.IsReadmeFile(f.Name, ".txt") {
-			rc, _ := f.Open()
-			data := make([]byte, f.UncompressedSize64)
-			rc.Read(data)
-			rc.Close()
-
-			share, err := core.ParseShare(data)
-			if err != nil {
-				t.Fatalf("parsing share: %v", err)
-			}
-			return share
-		}
-	}
-	t.Fatal("README file not found in bundle")
-	return nil
+	return share
 }
 
 func extractManifestFromBundle(t *testing.T, bundlePath string) []byte {
 	t.Helper()
-
-	r, err := zip.OpenReader(bundlePath)
+	data, err := bundle.ExtractManifestFromZip(bundlePath)
 	if err != nil {
-		t.Fatalf("opening bundle: %v", err)
+		t.Fatalf("extracting manifest from %s: %v", bundlePath, err)
 	}
-	defer r.Close()
-
-	var recoverData []byte
-	for _, f := range r.File {
-		if f.Name == "MANIFEST.age" {
-			rc, _ := f.Open()
-			data, _ := io.ReadAll(rc)
-			rc.Close()
-			return data
-		}
-		if f.Name == "recover.html" {
-			rc, _ := f.Open()
-			recoverData, _ = io.ReadAll(rc)
-			rc.Close()
-		}
-	}
-
-	// Fall back to extracting manifest from recover.html personalization data
-	if len(recoverData) > 0 {
-		manifest, err := html.ExtractManifestFromHTML(recoverData)
-		if err != nil {
-			t.Fatalf("extracting manifest from recover.html: %v", err)
-		}
-		return manifest
-	}
-
-	t.Fatal("MANIFEST.age not found in bundle and no recover.html to extract from")
-	return nil
+	return data
 }
 
 // TestAnonymousBundleGeneration tests bundle generation for anonymous projects


### PR DESCRIPTION
## What this changes

./rememory recover /Users/jojo/Downloads/bundle-share-1.zip  /Users/jojo/Downloads/bundle-share-2.zip

## How I tested this

Manual using the CLI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have reviewed the **entire diff** of this PR — every line of code and every line of text — and it reflects my understanding, not just an AI's output
- [x] I understand the changes and can explain why this approach is correct
- [x] I have removed AI-generated boilerplate, footers, and co-author lines
- [x] Tests pass (`make test`, and `make test-e2e` if I changed HTML/JS)
- [ ] This PR was authored and submitted by an AI agent without human review
