### PR TITLE
Warn users when running a version that's too old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to ReMemory are documented here.
 
 ## Unreleased
 
+- **Update nudge** — The CLI and web maker now gently let you know if you're running a version built more than six months ago, with a link to check for updates. No network calls — it just compares the build date to your clock.
+
 ## v0.0.16 — 2026-02-25
 
 - **Time-delayed recovery** — You can now set a waiting period when creating bundles. Even if your friends combine their pieces early, the files stay locked until the date you chose. Uses the [League of Entropy](https://www.cloudflare.com/en-ca/leagueofentropy/) — a distributed randomness beacon run by organizations around the world, not a single company. This is experimental: recovery requires a brief internet connection, and relies on the beacon continuing to operate. CLI: `rememory seal --timelock 30d`. Also available in the web maker under "Advanced options."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 BINARY := rememory
 VERSION := $(shell cat VERSION 2>/dev/null || echo "dev")
-LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
+BUILD_DATE := $(shell date -u +%Y-%m-%d)
+LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION) -X main.buildDate=$(BUILD_DATE)"
 
 # Build WASM module first, then the main binary
 build: wasm

--- a/cmd/rememory/main.go
+++ b/cmd/rememory/main.go
@@ -7,9 +7,10 @@ import (
 )
 
 var version = "dev"
+var buildDate = ""
 
 func main() {
-	if err := cmd.Execute(version); err != nil {
+	if err := cmd.Execute(version, buildDate); err != nil {
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/html.go
+++ b/internal/cmd/html.go
@@ -48,6 +48,7 @@ func runHTML(cmd *cobra.Command, args []string) error {
 	subcommand := args[0]
 
 	html.SetVersion(version)
+	html.SetBuildDate(buildDate)
 
 	var content string
 

--- a/internal/cmd/pages.go
+++ b/internal/cmd/pages.go
@@ -28,6 +28,7 @@ func generatePages(p *project.Project) error {
 	// Generate recover.html for static hosting.
 	// Tlock support is always included so the page can handle any manifest type.
 	html.SetVersion(version)
+	html.SetBuildDate(buildDate)
 	recoverHTML := html.GenerateRecoverHTML(nil, html.RecoverHTMLOptions{
 		StaticHosted: true,
 	})

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
-// version is set at build time via -ldflags
+// version and buildDate are set at build time via -ldflags
 var version = "dev"
+var buildDate = ""
 
 var rootCmd = &cobra.Command{
 	Use:   "rememory",
@@ -18,10 +23,31 @@ Seal the manifest:   rememory seal
 Recover from shares: rememory recover bundle-alice.zip bundle-bob.zip`,
 }
 
-func Execute(v string) error {
+func Execute(v, bd string) error {
 	version = v
+	buildDate = bd
 	rootCmd.Version = v
-	return rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err == nil {
+		checkBuildAge()
+	}
+	return err
+}
+
+// checkBuildAge prints a gentle nudge to stderr if the build is more than 6 months old.
+func checkBuildAge() {
+	if buildDate == "" {
+		return
+	}
+	built, err := time.Parse("2006-01-02", buildDate)
+	if err != nil {
+		return
+	}
+	if time.Since(built) < 180*24*time.Hour {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n%s You're running version %s, from %s.\n", yellow("A newer version may be available."), version, buildDate)
+	fmt.Fprintf(os.Stderr, "  Check https://github.com/eljojo/rememory/releases/latest\n\n")
 }
 
 // Color helpers (ANSI escape codes)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -75,6 +75,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		DataDir:         dataDir,
 		MaxManifestSize: maxSize,
 		Version:         version,
+		BuildDate:       buildDate,
 	})
 	if err != nil {
 		return fmt.Errorf("starting server: %w", err)

--- a/internal/html/assets/src/create-app.ts
+++ b/internal/html/assets/src/create-app.ts
@@ -168,7 +168,39 @@ declare const __SELFHOSTED__: boolean;
   // Initialization
   // ============================================
 
+  function checkBuildAge(): void {
+    const buildDate = window.BUILD_DATE;
+    if (!buildDate || buildDate === 'dev' || buildDate === '') return;
+
+    // Don't show on GitHub Pages (always up to date)
+    if (window.location.hostname === 'eljojo.github.io') return;
+
+    // Don't show on selfhosted (server operator manages updates)
+    if (__SELFHOSTED__) return;
+
+    const built = new Date(buildDate + 'T00:00:00Z');
+    if (isNaN(built.getTime())) return;
+
+    const now = new Date();
+    const sixMonths = 6 * 30 * 24 * 60 * 60 * 1000; // ~180 days
+    if (now.getTime() - built.getTime() < sixMonths) return;
+
+    toast.show({
+      type: 'info',
+      title: t('update_nudge_title'),
+      message: t('update_nudge_message', window.VERSION || 'dev', buildDate),
+      duration: 0,
+      actions: [{
+        id: 'check-updates',
+        label: t('update_nudge_action'),
+        primary: true,
+        onClick: () => window.open('https://github.com/eljojo/rememory/releases/latest', '_blank'),
+      }],
+    });
+  }
+
   async function init(): Promise<void> {
+    checkBuildAge();
     setupAnonymousMode();
     setupCustomLanguage();
     setupImport();

--- a/internal/html/assets/src/types.ts
+++ b/internal/html/assets/src/types.ts
@@ -189,6 +189,7 @@ declare global {
     // Embedded constants
     WASM_BINARY?: string;
     VERSION?: string;
+    BUILD_DATE?: string;
     MAX_TOTAL_FILE_SIZE?: number;
 
     // Localized README filenames (embedded in recover.html)

--- a/internal/html/assets/styles.css
+++ b/internal/html/assets/styles.css
@@ -938,6 +938,15 @@ footer a:hover {
   background: var(--error-dark);
 }
 
+.toast-info .toast-action-primary {
+  background: var(--info-text);
+  color: var(--paper-light);
+}
+
+.toast-info .toast-action-primary:hover {
+  background: #3A5A68;
+}
+
 .toast-close {
   position: absolute;
   top: 0.5rem;

--- a/internal/html/create.go
+++ b/internal/html/create.go
@@ -126,6 +126,7 @@ func GenerateMakerHTML(createWASMBytes []byte, opts MakerHTMLOptions) string {
   <script nonce="{{CSP_NONCE}}">
     window.WASM_BINARY = "` + createWASMB64 + `";
     window.VERSION = "{{VERSION}}";
+    window.BUILD_DATE = "{{BUILD_DATE}}";
     window.SELFHOSTED_CONFIG = ` + selfhostedConfigJSON + `;
     window.MAX_TOTAL_FILE_SIZE = ` + maxTotalFileSize + `;
   </script>`)

--- a/internal/html/layout.go
+++ b/internal/html/layout.go
@@ -42,8 +42,9 @@ func applyLayout(opts LayoutOptions) string {
 	}
 	html = strings.Replace(html, "{{LOGO_HREF}}", logoHref, 1)
 
-	// Replace version and GitHub URLs
+	// Replace version, build date, and GitHub URLs
 	html = strings.Replace(html, "{{VERSION}}", pkgVersion, -1)
+	html = strings.Replace(html, "{{BUILD_DATE}}", pkgBuildDate, -1)
 	html = strings.Replace(html, "{{GITHUB_REPO}}", core.GitHubRepo, -1)
 	html = strings.Replace(html, "{{GITHUB_PAGES}}", core.GitHubPages, -1)
 	html = strings.Replace(html, "{{GITHUB_URL}}", githubURL(), -1)

--- a/internal/html/version.go
+++ b/internal/html/version.go
@@ -10,10 +10,19 @@ import (
 // pkgVersion is the rememory version string, set once at startup via SetVersion.
 var pkgVersion string
 
+// pkgBuildDate is the build date (YYYY-MM-DD), set once at startup via SetBuildDate.
+var pkgBuildDate string
+
 // SetVersion sets the package-level version used by all Generate functions.
 // Call this once at startup before generating any HTML.
 func SetVersion(v string) {
 	pkgVersion = v
+}
+
+// SetBuildDate sets the package-level build date used by HTML generation.
+// Call this once at startup before generating any HTML.
+func SetBuildDate(d string) {
+	pkgBuildDate = d
 }
 
 // githubURL derives the GitHub release URL from pkgVersion.

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -17,6 +17,7 @@ type Config struct {
 	DataDir         string
 	MaxManifestSize int // Maximum MANIFEST.age size in bytes
 	Version         string
+	BuildDate       string
 }
 
 // Server implements http.Handler for the self-hosted ReMemory web app.
@@ -35,6 +36,7 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	html.SetVersion(cfg.Version)
+	html.SetBuildDate(cfg.BuildDate)
 
 	s := &Server{
 		store:           store,

--- a/internal/translations/maker/de.json
+++ b/internal/translations/maker/de.json
@@ -86,5 +86,9 @@
   "how_security_local": "Alles läuft in deinem Browser — nichts verlässt dein Gerät",
   "how_security_offline": "Diese Seite funktioniert offline — speichere sie mit Datei › Speichern unter",
   "how_security_encryption": "Geschützt mit age-Verschlüsselung",
-  "how_security_opensource": "Open Source (Apache-2.0)"
+  "how_security_opensource": "Open Source (Apache-2.0)",
+
+  "update_nudge_title": "Eine neuere Version ist möglicherweise verfügbar",
+  "update_nudge_message": "Du verwendest Version {0} vom {1}.",
+  "update_nudge_action": "Nach Updates suchen"
 }

--- a/internal/translations/maker/en.json
+++ b/internal/translations/maker/en.json
@@ -88,6 +88,10 @@
   "how_security_encryption": "Protected with age encryption",
   "how_security_opensource": "Open source (Apache-2.0)",
 
+  "update_nudge_title": "A newer version may be available",
+  "update_nudge_message": "You're running version {0}, from {1}.",
+  "update_nudge_action": "Check for updates",
+
   "saved_to_server": "Saved to server.",
   "save_to_server_error": "Could not save to server: {0}",
   "go_to_home": "Go to home page"

--- a/internal/translations/maker/es.json
+++ b/internal/translations/maker/es.json
@@ -86,5 +86,9 @@
   "how_security_local": "Todo ocurre en tu navegador — nada sale de tu dispositivo",
   "how_security_offline": "Esta página funciona sin conexión — guárdala con Archivo › Guardar como",
   "how_security_encryption": "Protegido con cifrado age",
-  "how_security_opensource": "Código abierto (Apache-2.0)"
+  "how_security_opensource": "Código abierto (Apache-2.0)",
+
+  "update_nudge_title": "Puede haber una versión más reciente",
+  "update_nudge_message": "Estás usando la versión {0}, de {1}.",
+  "update_nudge_action": "Buscar actualizaciones"
 }

--- a/internal/translations/maker/fr.json
+++ b/internal/translations/maker/fr.json
@@ -86,5 +86,9 @@
   "how_security_local": "Tout se passe dans votre navigateur — rien ne quitte votre appareil",
   "how_security_offline": "Cette page fonctionne hors ligne — enregistrez-la avec Fichier › Enregistrer sous",
   "how_security_encryption": "Protégé par le chiffrement age",
-  "how_security_opensource": "Open source (Apache-2.0)"
+  "how_security_opensource": "Open source (Apache-2.0)",
+
+  "update_nudge_title": "Une version plus récente est peut-être disponible",
+  "update_nudge_message": "Vous utilisez la version {0}, du {1}.",
+  "update_nudge_action": "Vérifier les mises à jour"
 }

--- a/internal/translations/maker/pt.json
+++ b/internal/translations/maker/pt.json
@@ -86,5 +86,9 @@
   "how_security_local": "Tudo acontece no seu navegador — nada sai do seu dispositivo",
   "how_security_offline": "Esta página funciona offline — salve com Arquivo › Salvar como",
   "how_security_encryption": "Protegido com criptografia age",
-  "how_security_opensource": "Código aberto (Apache-2.0)"
+  "how_security_opensource": "Código aberto (Apache-2.0)",
+
+  "update_nudge_title": "Uma versão mais recente pode estar disponível",
+  "update_nudge_message": "Você está usando a versão {0}, de {1}.",
+  "update_nudge_action": "Verificar atualizações"
 }

--- a/internal/translations/maker/sl.json
+++ b/internal/translations/maker/sl.json
@@ -86,5 +86,9 @@
   "how_security_local": "Vse poteka v vašem brskalniku — nič ne zapusti vaše naprave",
   "how_security_offline": "Ta stran deluje brez povezave — shranite jo z Datoteka › Shrani kot",
   "how_security_encryption": "Zaščiteno s šifriranjem age",
-  "how_security_opensource": "Odprtokodno (Apache-2.0)"
+  "how_security_opensource": "Odprtokodno (Apache-2.0)",
+
+  "update_nudge_title": "Morda je na voljo novejša različica",
+  "update_nudge_message": "Uporabljate različico {0} iz {1}.",
+  "update_nudge_action": "Preveri posodobitve"
 }

--- a/internal/translations/maker/zh-TW.json
+++ b/internal/translations/maker/zh-TW.json
@@ -86,5 +86,9 @@
   "how_security_local": "所有操作都在你的瀏覽器中進行 — 不會離開你的裝置",
   "how_security_offline": "這個頁面可以離線使用 — 用檔案 › 另存新檔儲存",
   "how_security_encryption": "使用 age 加密保護",
-  "how_security_opensource": "開放原始碼 (Apache-2.0)"
+  "how_security_opensource": "開放原始碼 (Apache-2.0)",
+
+  "update_nudge_title": "可能有更新的版本",
+  "update_nudge_message": "目前使用版本 {0}，建立於 {1}。",
+  "update_nudge_action": "檢查更新"
 }


### PR DESCRIPTION
## What this changes

Adds a little nudge message suggesting users check if there's updates

## How I tested this

<img width="543" height="156" alt="image" src="https://github.com/user-attachments/assets/65455dc6-2149-4eb3-a0c4-79cd28d963c6" />
<img width="857" height="379" alt="image" src="https://github.com/user-attachments/assets/82015ab4-e15e-4524-a7e6-c96b7525d563" />


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] Tests pass (`make full`)
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
