### PR TITLE
fix: use proper styling for "Why I built this" background note card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build: wasm
 # using the offline drand client (zero HTTP calls).
 # tlock-recover.ts is imported by app.ts behind __TLOCK__ guards.
 ts:
+	@if [ ! -d node_modules ]; then echo "Run 'npm install' first"; exit 1; fi
 	@echo "Compiling TypeScript..."
 	esbuild internal/html/assets/src/shared.ts --bundle --format=iife --global-name=_shared --outfile=internal/html/assets/shared.js --target=es2020
 	esbuild internal/html/assets/src/app.ts --bundle --format=iife --define:__TLOCK__=false --minify-syntax --outfile=internal/html/assets/app.js --target=es2020 --loader:.txt=text --conditions=zbar-inlined

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ This uses the [League of Entropy](https://www.cloudflare.com/en-ca/leagueofentro
 # Using Nix (recommended)
 nix develop
 
+# Install dependencies
+npm install
+
 # Build
 make build
 

--- a/internal/html/assets/about.html
+++ b/internal/html/assets/about.html
@@ -27,7 +27,7 @@
       </div>
     </section>
 
-    <section class="background">
+    <section class="background card-muted">
       <h2 data-i18n="bg_title">Why I built this</h2>
       <p data-i18n-html="bg_2">
         When I watched <a href="https://www.youtube.com/watch?v=k_P7Y0-wgos" target="_blank">a documentary about Clive Wearing</a>, a man who has lived with severe amnesia since 1985, it changed how I thought about my own digital life. Memory is more fragile than we like to believe.
@@ -72,7 +72,7 @@
       </figure>
     </section>
 
-    <section class="trust">
+    <section class="trust card-muted">
       <h2 data-i18n="trust_title">On trust and verification</h2>
       <ul>
         <li data-i18n-html="trust_6">Encryption uses <a href="https://github.com/FiloSottile/age" target="_blank">age</a> — a modern, well-regarded tool</li>

--- a/internal/html/assets/index.css
+++ b/internal/html/assets/index.css
@@ -240,14 +240,15 @@
       font-size: 0.85rem;
     }
 
-    /* Trust section */
-    .trust {
+    /* Muted card — used for contextual/background sections */
+    .card-muted {
       background: var(--sand);
       border-radius: 8px;
       padding: 1.5rem 2rem;
       margin-bottom: 1.5rem;
     }
 
+    /* Trust section */
     .trust h2 {
       font-size: 1.1rem;
       color: var(--text);
@@ -303,13 +304,6 @@
     }
 
 /* Background note */
-    .background {
-      background: var(--paper-light);
-      border-radius: 8px;
-      padding: 1.5rem 2rem;
-      box-shadow: 0 2px 4px rgba(46,42,38,0.08);
-      margin-bottom: 1.5rem;
-    }
 
     .background h2 {
       font-size: 1.1rem;


### PR DESCRIPTION
## What this changes

The "Why I built this" card has a smaller h2 font-size (~18px) compared to the other 'main' cards (20px). The only other card that also has the smaller h2 font-size is the "On trust and verification" card which has a more muted/grayed out style.

It caught my OCD eye, so I wanted to adjust this :D. I'd argue to use the bigger font size or use the muted card style for the "Why I built this" card, I opted for the latter.

Summary:
- Introduce `.card-muted` as a shared utility class to avoid duplicating these 'muted' card styles.
- Adjust style of "Why I built this" card to use the muted style, as its header was already using a smaller font-size.
- Add `npm install` instruction for development before running `make build` which would fail without it.
- Add check if the `node_modules` folder is present in the `make ts` command.

<!-- What does this PR do and why? Link to related issues if any. -->
Before:
<img width="771" height="423" alt="image" src="https://github.com/user-attachments/assets/f5b6ad6a-6096-42b9-b60f-f3d4c97f6b9f" />

After:
<img width="839" height="395" alt="image" src="https://github.com/user-attachments/assets/802a0534-8b6b-4a16-9d02-6b42723420a2" />

## How I tested this

See screenshots
<!-- How did you verify it works? Tests you ran, manual steps, etc. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] Tests pass (`make full`)
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
