### PR TITLE
run docker image as non-root user

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,12 +137,20 @@
             inherit tag;
             copyToRoot = pkgs.buildEnv {
               name = "rememory-root";
-              paths = [ rememoryPkg ];
+              paths = [
+                rememoryPkg
+                pkgs.dockerTools.fakeNss
+              ];
             };
+            runAsRoot = ''
+              mkdir -p /data
+              chown 65534:65534 /data
+            '';
             config = {
               Cmd = [ "${rememoryPkg}/bin/rememory" "serve" "--host" "0.0.0.0" "--port" "8080" "--data" "/data" ];
               ExposedPorts = { "8080/tcp" = { }; };
               Volumes = { "/data" = { }; };
+              User = "65534:65534";
             };
           } // pkgs.lib.optionalAttrs (arch != null) { architecture = arch; });
 


### PR DESCRIPTION
Runs the container as nobody (65534) instead of root. The server only needs port 8080 and write access to `/data`.

Three changes to `mkDockerImage`:
- `fakeNss` in image paths (provides `/etc/passwd`)
- `runAsRoot` to pre-create `/data` owned by 65534
- `User = "65534:65534"` in config

Applies to both amd64 and arm64 images since both use `mkDockerImage`.

**Upgrade note:** existing deployments with named volumes will have `/data` owned by root. One-time fix: `docker exec <container> chown -R 65534:65534 /data` before restarting with the new image.

Closes #125