### PR TITLE
use forward slashes in tar and zip archive paths

### DIFF
--- a/internal/manifest/archive.go
+++ b/internal/manifest/archive.go
@@ -76,7 +76,7 @@ func ArchiveTarGz(w io.Writer, sourceDir string) (*ArchiveResult, error) {
 			return fmt.Errorf("creating header for %s: %w", path, err)
 		}
 
-		header.Name = relPath
+		header.Name = filepath.ToSlash(relPath)
 
 		// Ensure directory entries end with /
 		if info.IsDir() {
@@ -174,7 +174,7 @@ func ExtractTarGz(r io.Reader, destDir string) (*ExtractResult, error) {
 		}
 
 		// Track the root directory
-		parts := strings.Split(header.Name, string(filepath.Separator))
+		parts := strings.Split(header.Name, "/")
 		if len(parts) > 0 && rootDir == "" {
 			rootDir = parts[0]
 		}
@@ -319,7 +319,7 @@ func ArchiveZip(w io.Writer, sourceDir string) (*ArchiveResult, error) {
 		}
 
 		// Ensure directory entries end with /
-		name := relPath
+		name := filepath.ToSlash(relPath)
 		if info.IsDir() {
 			name += "/"
 		}


### PR DESCRIPTION
filepath.Rel returns backslashes on Windows. tar and zip specs require forward slashes. Archives created on Windows wouldn't extract correctly in recover.html since parseTar splits on "/".

Three changes in archive.go:
- tar write: `filepath.ToSlash(relPath)` 
- tar extract: split on `"/"` instead of `filepath.Separator`
- zip write: `filepath.ToSlash(relPath)`

Also fixes cross-platform extraction (archive created on one OS, extracted on another).

Closes #106