### PR TITLE
feat: add message command for bundle distribution

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/eljojo/rememory/internal/core"
+	"github.com/eljojo/rememory/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var messageCmd = &cobra.Command{
+	Use:   "message",
+	Short: "Generate messages to send with each friend's bundle",
+	Long: `Generate personalized messages for each friend explaining their
+bundle and what to do with it.
+
+Use after sealing to help distribute bundles. The messages are designed
+to be copied into any messaging app, email, or read aloud.
+
+Use --rotation when distributing updated bundles after re-sealing.
+
+Example:
+  rememory message
+  rememory message --rotation
+  rememory message --friend Alice`,
+	RunE: runMessage,
+}
+
+func init() {
+	messageCmd.Flags().Bool("rotation", false, "Generate shorter messages for updated bundles (friends already know what this is)")
+	messageCmd.Flags().String("friend", "", "Generate message for a single friend")
+	rootCmd.AddCommand(messageCmd)
+}
+
+func runMessage(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+
+	projectDir, err := project.FindProjectDir(cwd)
+	if err != nil {
+		return fmt.Errorf("no rememory project found (run 'rememory init' first)")
+	}
+
+	p, err := project.Load(projectDir)
+	if err != nil {
+		return fmt.Errorf("loading project: %w", err)
+	}
+
+	if p.Sealed == nil {
+		return fmt.Errorf("project is not sealed yet — run 'rememory seal' first")
+	}
+
+	rotation, _ := cmd.Flags().GetBool("rotation")
+	friendFilter, _ := cmd.Flags().GetString("friend")
+
+	return printMessages(p, rotation, friendFilter)
+}
+
+func printMessages(p *project.Project, rotation bool, friendFilter string) error {
+	bundlesDir := filepath.Join(p.OutputPath(), "bundles")
+
+	for _, friend := range p.Friends {
+		if friendFilter != "" && !strings.EqualFold(friend.Name, friendFilter) {
+			continue
+		}
+
+		bundleFilename := fmt.Sprintf("bundle-%s.zip", core.SanitizeFilename(friend.Name))
+		bundlePath := filepath.Join(bundlesDir, bundleFilename)
+
+		// Check bundle exists
+		bundleInfo := ""
+		if info, err := os.Stat(bundlePath); err == nil {
+			bundleInfo = fmt.Sprintf(" (%s)", formatSize(info.Size()))
+		}
+
+		// Header
+		fmt.Println(strings.Repeat("\u2500", 56))
+		contactLine := ""
+		if friend.Contact != "" {
+			contactLine = fmt.Sprintf(" (%s)", friend.Contact)
+		}
+		fmt.Printf("  %s%s\n", friend.Name, contactLine)
+
+		label := bundleFilename
+		if rotation {
+			label += " (updated)"
+		}
+		fmt.Printf("  Bundle: %s%s\n", label, bundleInfo)
+		fmt.Println(strings.Repeat("\u2500", 56))
+		fmt.Println()
+
+		if rotation {
+			printRotationMessage(friend, bundleFilename)
+		} else {
+			printInitialMessage(friend, bundleFilename, p.Threshold, len(p.Friends))
+		}
+
+		fmt.Println()
+	}
+
+	if friendFilter != "" {
+		found := false
+		for _, f := range p.Friends {
+			if strings.EqualFold(f.Name, friendFilter) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("no friend named %q in this project", friendFilter)
+		}
+	}
+
+	return nil
+}
+
+func printInitialMessage(friend project.Friend, bundleFilename string, threshold, total int) {
+	name := friend.Name
+
+	fmt.Printf("Hi %s,\n\n", name)
+
+	fmt.Printf("I'm sending you a file called %s as part of\n", bundleFilename)
+	fmt.Println("something I've set up to protect my important digital files.")
+	fmt.Println()
+
+	fmt.Printf("You're one of %d people I trust with a piece of the key. No\n", total)
+	fmt.Printf("single person can open my files alone. If something happens\n")
+	fmt.Printf("to me, any %d of you can work together to unlock them.\n", threshold)
+	fmt.Println()
+
+	fmt.Println("All you need to do is keep the ZIP file somewhere you won't")
+	fmt.Println("lose it. A folder on your computer, a USB drive, or even")
+	fmt.Println("printed out. You don't need to install anything or create")
+	fmt.Println("an account.")
+	fmt.Println()
+
+	fmt.Println("If recovery is ever needed, open the file called recover.html")
+	fmt.Println("inside the ZIP. It works in any browser and has instructions")
+	fmt.Println("for what to do next, including how to reach the others.")
+	fmt.Println()
+
+	fmt.Println("Thank you for holding onto this.")
+}
+
+func printRotationMessage(friend project.Friend, bundleFilename string) {
+	name := friend.Name
+
+	fmt.Printf("Hi %s,\n\n", name)
+
+	fmt.Printf("I've updated my recovery bundles. Please replace your old\n")
+	fmt.Printf("%s with the new one I'm sending.\n\n", bundleFilename)
+
+	fmt.Println("The old bundle no longer works for recovery. Everything")
+	fmt.Println("else stays the same.")
+}

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/eljojo/rememory/internal/project"
+)
+
+func TestPrintMessages_Initial(t *testing.T) {
+	p := &project.Project{
+		Name:      "test-safe",
+		Threshold: 2,
+		Friends: []project.Friend{
+			{Name: "Alice", Contact: "alice@email.com"},
+			{Name: "Bob", Contact: "555-1234"},
+			{Name: "Camila"},
+		},
+		Sealed: &project.Sealed{},
+		Path:   t.TempDir(),
+	}
+
+	// Create output/bundles directory (printMessages checks for bundle files)
+	os.MkdirAll(p.OutputPath()+"/bundles", 0755)
+
+	output := captureStdout(t, func() {
+		err := printMessages(p, false, "")
+		if err != nil {
+			t.Fatalf("printMessages failed: %v", err)
+		}
+	})
+
+	// Check all friends appear
+	if !strings.Contains(output, "Alice") {
+		t.Error("output missing Alice")
+	}
+	if !strings.Contains(output, "Bob") {
+		t.Error("output missing Bob")
+	}
+	if !strings.Contains(output, "Camila") {
+		t.Error("output missing Camila")
+	}
+
+	// Check bundle filenames
+	if !strings.Contains(output, "bundle-alice.zip") {
+		t.Error("output missing bundle-alice.zip")
+	}
+
+	// Check contact info appears in header
+	if !strings.Contains(output, "alice@email.com") {
+		t.Error("output missing alice@email.com")
+	}
+	if !strings.Contains(output, "555-1234") {
+		t.Error("output missing 555-1234")
+	}
+
+	// Check threshold and total are mentioned
+	if !strings.Contains(output, "3 people") {
+		t.Error("output missing total count (3 people)")
+	}
+	if !strings.Contains(output, "any 2 of you") {
+		t.Error("output missing threshold (any 2)")
+	}
+
+	// Check it doesn't mention "rememory" in the message body
+	// (the tool name should stay out of friend-facing messages)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "rememory") && !strings.Contains(lower, "bundle:") {
+			// Allow "rememory" in the header/bundle filename, not in the message body
+			if !strings.HasPrefix(strings.TrimSpace(line), "Bundle:") &&
+				!strings.Contains(line, "\u2500") {
+				t.Errorf("message body mentions 'rememory': %s", line)
+			}
+		}
+	}
+}
+
+func TestPrintMessages_Rotation(t *testing.T) {
+	p := &project.Project{
+		Name:      "test-safe",
+		Threshold: 2,
+		Friends: []project.Friend{
+			{Name: "Alice"},
+			{Name: "Bob"},
+		},
+		Sealed: &project.Sealed{},
+		Path:   t.TempDir(),
+	}
+	os.MkdirAll(p.OutputPath()+"/bundles", 0755)
+
+	output := captureStdout(t, func() {
+		err := printMessages(p, true, "")
+		if err != nil {
+			t.Fatalf("printMessages failed: %v", err)
+		}
+	})
+
+	// Rotation messages should be shorter
+	if !strings.Contains(output, "updated") {
+		t.Error("rotation message missing 'updated'")
+	}
+	if !strings.Contains(output, "no longer works") {
+		t.Error("rotation message missing 'no longer works'")
+	}
+
+	// Should NOT contain the full initial explanation
+	if strings.Contains(output, "recover.html") {
+		t.Error("rotation message should not re-explain recover.html")
+	}
+}
+
+func TestPrintMessages_FriendFilter(t *testing.T) {
+	p := &project.Project{
+		Name:      "test-safe",
+		Threshold: 2,
+		Friends: []project.Friend{
+			{Name: "Alice"},
+			{Name: "Bob"},
+			{Name: "Camila"},
+		},
+		Sealed: &project.Sealed{},
+		Path:   t.TempDir(),
+	}
+	os.MkdirAll(p.OutputPath()+"/bundles", 0755)
+
+	output := captureStdout(t, func() {
+		err := printMessages(p, false, "Bob")
+		if err != nil {
+			t.Fatalf("printMessages failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Bob") {
+		t.Error("filtered output missing Bob")
+	}
+	if strings.Contains(output, "Hi Alice") {
+		t.Error("filtered output should not contain Alice's message")
+	}
+	if strings.Contains(output, "Hi Camila") {
+		t.Error("filtered output should not contain Camila's message")
+	}
+}
+
+func TestPrintMessages_FriendNotFound(t *testing.T) {
+	p := &project.Project{
+		Name:      "test-safe",
+		Threshold: 2,
+		Friends: []project.Friend{
+			{Name: "Alice"},
+		},
+		Sealed: &project.Sealed{},
+		Path:   t.TempDir(),
+	}
+	os.MkdirAll(p.OutputPath()+"/bundles", 0755)
+
+	err := printMessages(p, false, "Nobody")
+	if err == nil {
+		t.Error("expected error for unknown friend")
+	}
+	if !strings.Contains(err.Error(), "Nobody") {
+		t.Errorf("error should mention the friend name: %v", err)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}

--- a/internal/cmd/seal.go
+++ b/internal/cmd/seal.go
@@ -39,6 +39,7 @@ func init() {
 	sealCmd.Flags().Bool("no-embed-manifest", false, "Do not embed MANIFEST.age in recover.html (it is embedded by default when 10 MB or less)")
 	sealCmd.Flags().String("timelock", "", "Time-lock duration or date (e.g., 5min, 30d, 6m, 1y, 2027-06-15T00:00:00Z)")
 	sealCmd.Flags().Bool("pages", false, "Generate a static pages directory (recover.html + MANIFEST.age) for hosting")
+	sealCmd.Flags().Bool("message", false, "Print distribution messages for each friend after bundling")
 	rootCmd.AddCommand(sealCmd)
 }
 
@@ -78,6 +79,14 @@ func runSeal(cmd *cobra.Command, args []string) error {
 	if pages {
 		if err := generatePages(p); err != nil {
 			return err
+		}
+	}
+
+	showMessage, _ := cmd.Flags().GetBool("message")
+	if showMessage {
+		fmt.Println()
+		if err := printMessages(p, false, ""); err != nil {
+			return fmt.Errorf("generating messages: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## What this changes

Adds a `rememory message` command that generates personalized, copy-paste messages for each friend explaining their bundle and what to do with it.

After `rememory seal` prints bundle paths, the creator is on their own for the hardest step: actually getting the bundles to friends and explaining what they are.. so I wanted to build this command to close that gap.

Two modes:
- **Initial distribution** (`rememory message`): full explanation for friends who have never seen a bundle before
- **Rotation** (`rememory message --rotation`): shorter message for friends who already know what this is, just need to swap their old bundle

Also adds `--friend NAME` to filter to a single friend, and `--message` flag on `seal` for a single-command workflow.

## How I tested this

- 4 Go unit tests covering initial messages, rotation messages, friend filtering, and unknown friend error handling
- Built the binary and ran `rememory message` against a test project with 3 friends (2 with contact info, 1 without)
- Verified `rememory seal --message` prints messages after bundling
- Verified rotation mode produces shorter messages that don't re-explain recover.html
- Verified messages don't mention "rememory" by name in the body (it's about the person, not the tool)
- `go test ./...` passes (560 tests, 4 new)

![demo](https://vhs.charm.sh/vhs-1p5I1t1AogMIJslAxwslX6.gif)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] Tests pass (`make full`)
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)